### PR TITLE
fix: exit code from reporter.py script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,11 +34,11 @@ echo "::group::appinspect"
 rm -f $INPUT_RESULT_FILE || true 1>/dev/null
 echo running: splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
 splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
-test_exit_code=$?
 if [ ! -f $INPUT_RESULT_FILE ]; then echo no result file; exit 1; fi
 echo "::endgroup::"
 
 echo "::group::reporter"
 python3 /reporter.py $INPUT_RESULT_FILE
+test_exit_code=$?
 echo "::endgroup::"
 exit "$test_exit_code"


### PR DESCRIPTION
splunk-appinspect returns 0 exit code if it has failures.