### PR TITLE
feat: support for manual tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,17 @@ on:
       - "develop"
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install actionlint
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.3/scripts/download-actionlint.bash)
+      - uses: pre-commit/action@v2.0.3
   build_action:
     runs-on: ubuntu-latest
     name: Build Action

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py3-plus]
+-   repo: https://github.com/psf/black
+    rev: 21.9b0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+    -   id: isort
+-   repo: local
+    hooks:
+      - id: actionlint
+        name: actionlint
+        entry: actionlint
+        args: [-ignore, 'property ".+" is not defined in object type']
+        language: script
+        types: ["yaml"]
+        files: ^.github/workflows/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN pip install --no-cache-dir --prefer-binary -r /requirements.txt
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /
 COPY reporter.py /
+COPY compare_checks.py /
+COPY export_to_markdown.py /
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 WORKDIR /github/workspace
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["bash", "-x", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ uses: splunk/appinspect-cli-action@v1
 with:
   app_path: 'test'
 ```
+
+# Section for Appinspect manual

--- a/README.md
+++ b/README.md
@@ -17,7 +17,28 @@ For a more comprehensive Splunk app testing workflow, visit the [`splunk/splunk-
 
 ### `result-file`
 The file name to use for the json result.
+
 `default`: `appinspect_result.json`
+
+### `included_tags`
+Appinspect tags to include
+
+`required`: `false`
+  
+### `excluded_tags`
+Appinspect tags to exclude
+
+`required`: `false`
+
+### `app_vetting`
+Path to app vetting yaml file. Used only if `manual` in `included_tags`
+
+`default`: `.app-vetting.yaml`
+
+### `manual_check_markdown`
+Path for generated file with markdown for manual checks. Used only if `manual` in `included_tags`
+
+`default`: `manual_check_markdown.txt`
 
 ## Outputs
 
@@ -32,5 +53,28 @@ uses: splunk/appinspect-cli-action@v1
 with:
   app_path: 'test'
 ```
+### Downloading manual checks markdown
+If the comparison is successful then a markdown consisting a table with manual check names and comments is generated. It can be uploaded to artifacts.
+```yml
+- name: upload-manual-check-markodown
+        uses: actions/upload-artifact@v2
+        with:
+          name: manual_check_markdown.txt
+          path: manual_check_markdown.txt
+```
+The markdown is ready to paste into confluence, by:
+`Edit -> Insert more content -> Markup`, change insert type to `Markdown` and paste the contents of the file
 
-# Section for Appinspect manual
+## Using manual tag
+Running `appinspect-cli-action` with `manual` tag in `included_tags` detects checks that need to be verified manually and tests if all of them were already reviewed - if not the action will fail.
+### Manual checks review
+To see checks to be verified inspect the `result_file` from `appinspect-cli-action` run with manual tag. Verify manual checks and mark them as reviewed by adding them one by one into `.app-vetting.yaml`, ex:
+```yml
+name_of_manual_check_1:
+  comment: 'your comment'
+name_of_manual_check_2:
+  comment: 'your comment'
+```
+please note that names of validated manual checks should be aligned with those from `result_file` and your comment can't be empty.
+### Running the job
+When `appinspect-cli-action` is called with `manual` tag, it scans the package with Splunk's AppInspect CLI and searches for manual checks. In the next step, action compares `results_file` with `.app-vetting.yaml` if any check wasn't reviewed and isn't in `.app-vetting.yaml` then the job fails.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This can be uploaded for later viewing to use in another step/job using [`action
 
 For a more comprehensive Splunk app testing workflow, visit the [`splunk/splunk-app-testing`](https://github.com/splunk/splunk-app-testing) which includes a workflow for cypress testing.
 
-
 ## Inputs
 
 ### `app_path`
@@ -46,25 +45,6 @@ Path for generated file with markdown for manual checks. Used only if `manual` i
 
 `pass|fail`
 
-## Example usage
-
-```yml
-uses: splunk/appinspect-cli-action@v1
-with:
-  app_path: 'test'
-```
-### Downloading manual checks markdown
-If the comparison is successful then a markdown consisting a table with manual check names and comments is generated. It can be uploaded to artifacts.
-```yml
-- name: upload-manual-check-markodown
-        uses: actions/upload-artifact@v2
-        with:
-          name: manual_check_markdown.txt
-          path: manual_check_markdown.txt
-```
-The markdown is ready to paste into confluence, by:
-`Edit -> Insert more content -> Markup`, change insert type to `Markdown` and paste the contents of the file
-
 ## Using manual tag
 Running `appinspect-cli-action` with `manual` tag in `included_tags` detects checks that need to be verified manually and tests if all of them were already reviewed - if not the action will fail.
 ### Manual checks review
@@ -78,3 +58,28 @@ name_of_manual_check_2:
 please note that names of validated manual checks should be aligned with those from `result_file` and your comment can't be empty.
 ### Running the job
 When `appinspect-cli-action` is called with `manual` tag, it scans the package with Splunk's AppInspect CLI and searches for manual checks. In the next step, action compares `results_file` with `.app-vetting.yaml` if any check wasn't reviewed and isn't in `.app-vetting.yaml` then the job fails.
+
+## Example usage
+
+```yml
+- uses: splunk/appinspect-cli-action@v1
+  with:
+    app_path: 'test'
+```
+### Downloading manual checks markdown
+If the comparison is successful then a markdown consisting a table with manual check names and comments is generated. It can be uploaded to artifacts.
+```yml
+- uses: actions/checkout@v2
+- uses: splunk/appinspect-cli-action@v1.3
+  with:
+    app_path: 'test'
+    included_tags: manual
+    manual_check_markdown: manual_check_markdown.txt
+- name: upload-manual-check-markodown
+  uses: actions/upload-artifact@v2
+  with:
+    name: manual_check_markdown.txt
+    path: manual_check_markdown.txt
+```
+The markdown is ready to paste into confluence, by:
+`Edit -> Insert more content -> Markup`, change insert type to `Markdown` and paste the contents of the file

--- a/action.yml
+++ b/action.yml
@@ -27,4 +27,4 @@ outputs:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.3.0-develop.1"
+  image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -27,4 +27,4 @@ outputs:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.3.0-develop.1"

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,17 @@ inputs:
   excluded_tags:
     description: "Tags to exclude"
     required: false
+  app_vetting:
+    description: "Path to app vetting yaml file"
+    required: false
+    default: ".app-vetting.yaml"
+  manual_check_markdown:
+    description: "Path for generated file with markdown for manual checks"
+    required: false
+    default: "manual_check_markdown.txt"
 outputs:
   status:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.2.0"
+  image: "Dockerfile"

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -1,0 +1,125 @@
+import json
+import os
+import sys
+from typing import List
+
+import yaml
+
+print(
+    f"{os.path.basename(__file__)} script was called with parameters: {' '.join(sys.argv[1:])}"
+)
+APP_VETTING_PATH = sys.argv[1]
+APPINSPECT_OUTPUT_PATH = sys.argv[2]
+
+
+class BCOLORS:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+def compare(
+    vetting_file: str = ".app-vetting.yaml",
+    appinspect_result_file: str = "appinspect_output.json",
+) -> List[str]:
+    """
+    Compares checks from vetting file and appinspect result file. A lot prints are added to make it
+    easier for users to create proper vetting_file and understand errors
+
+    :param vetting_file: path to yaml file with verified manual checks
+    :param appinspect_result_file: path to Splunk's AppInspect CLI result file
+    :return: list of non matching tests between vetting_file and appinspect_result_file or not commented ones
+    """
+    if not os.path.isfile(vetting_file):
+        raise FileNotFoundError(
+            f"File {vetting_file} does not exist. Create it and fill out with list of verified manual checks"
+        )
+
+    if not os.path.isfile(appinspect_result_file):
+        raise FileNotFoundError(
+            f"File {appinspect_result_file} does not exist. Something went wrong with report generation"
+        )
+
+    manual_checks = get_checks_from_appinspect_result(appinspect_result_file)
+
+    with open(vetting_file) as f:
+        vetting_data = yaml.safe_load(f)
+    if vetting_data is None:
+        if manual_checks:
+            print(
+                f"{BCOLORS.WARNING}{BCOLORS.BOLD}{vetting_file} is empty. You can initilize it with below yaml content."
+                f" Every check requires some comment which means that check was manually verified{BCOLORS.ENDC}"
+            )
+            for check in manual_checks:
+                print(f"{BCOLORS.WARNING}{BCOLORS.BOLD}{check}:{BCOLORS.ENDC}")
+                print(f"{BCOLORS.WARNING}{BCOLORS.BOLD}  comment: ''{BCOLORS.ENDC}")
+            print()
+        vetting_data = {}
+
+    new_checks = list(set(manual_checks) - set(vetting_data.keys()))
+    deprecated_checks = vetting_data.keys() - manual_checks
+
+    if new_checks:
+        print(
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}Some manual checks were found in appinspect output, which are not present in"
+            f" {vetting_file}. List of checks:{BCOLORS.ENDC}"
+        )
+        for check in new_checks:
+            print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
+
+    if deprecated_checks:
+        print(
+            f"{BCOLORS.WARNING}{BCOLORS.BOLD}Some manual checks were found in {vetting_file}, which are not present in"
+            f" appinspect output. Please delete them, as they are deprecated. List of checks:{BCOLORS.ENDC}"
+        )
+        for check in deprecated_checks:
+            print(f"{BCOLORS.WARNING}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
+    not_commented = []
+
+    for check, info in vetting_data.items():
+        if not info.get("comment"):
+            not_commented.append(check)
+
+    if not_commented:
+        print(
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified manual checks require comment. Below checks are not commented in"
+            f" {vetting_file}:{BCOLORS.ENDC}"
+        )
+        for check in not_commented:
+            print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
+
+    return new_checks + not_commented
+
+
+def get_checks_from_appinspect_result(path: str) -> List[str]:
+    """
+    Returns manual checks from appinspect json result file
+
+    :param path: path to json result file
+    :return: list of checks in string format
+    """
+    manual_checks = []
+    with open(path) as f:
+        appinspect_results = json.load(f)
+        for report in appinspect_results["reports"]:
+            for group in report["groups"]:
+                for check in group["checks"]:
+                    if check["result"] == "manual_check":
+                        manual_checks.append(check["name"])
+    return manual_checks
+
+
+def main():
+    not_verified_checks = compare(APP_VETTING_PATH, APPINSPECT_OUTPUT_PATH)
+    if not_verified_checks:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -94,6 +94,9 @@ def compare(
         for check in not_commented:
             print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
 
+    if new_checks or not_commented:
+        print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}Please see appinspect report for more detailed description about manual checks and review them accordingly.{BCOLORS.ENDC}")
+
     return new_checks + not_commented
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,6 @@ echo "::endgroup::"
 
 if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $test_exit_code == 0 ]; then
   echo "::group::manual_checks"
-  echo "/compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE"
   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE
   test_exit_code=$?
   if [ $test_exit_code == 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,4 +41,18 @@ echo "::group::reporter"
 python3 /reporter.py $INPUT_RESULT_FILE
 test_exit_code=$?
 echo "::endgroup::"
+
+if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $test_exit_code == 0 ]; then
+  echo "::group::manual_checks"
+  echo "/compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE"
+  python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE
+  test_exit_code=$?
+  if [ $test_exit_code == 0 ]; then
+    echo "successful comparison, generating markdown"
+    echo "/export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN"
+    python3 /export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN
+  fi
+  echo "::endgroup::"
+fi
+
 exit "$test_exit_code"

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -1,0 +1,67 @@
+import sys
+
+import yaml
+
+APP_VETTING_PATH = sys.argv[1]
+MARKDOWN_OUTPUT_PATH = sys.argv[2]
+
+MARKDOWN_START = """<div class=3D"table-wrap">
+<table class=3D"confluenceTable">
+<tbody>
+<tr>
+<th class=3D"confluenceTh">manual check</th>
+<th class=3D"confluenceTh">comment</th>
+</tr>
+"""
+
+CHECK_MARKDOWN_TEMPLATE = """<tr>
+<td class=3D"confluenceTh">{manual_check}</th>
+<td class=3D"confluenceTh">{comment}</th>
+</tr>
+"""
+
+MARKDOWN_END = """</tbody>
+</table>
+</div>"""
+
+
+class ExportToMarkdown:
+    """
+    Based on app vetting file generates file with markdown consisting names of validated checks and comments.
+    """
+
+    def __init__(self, manual_checks_path, markdown_output_path):
+        self.manual_checks_path = manual_checks_path
+        self.markdown_output_path = markdown_output_path
+        self.manual_checks = None
+
+    def __call__(self):
+        self._load_manual_checks()
+        self._create_output_markup()
+
+    def _load_manual_checks(self):
+        with open(self.manual_checks_path) as vetting_data:
+            self.manual_checks = yaml.safe_load(vetting_data)
+        if self.manual_checks is None:
+            self.manual_checks = {}
+
+    def _create_output_markup(self):
+        with open(self.markdown_output_path, "w") as output:
+            output.write(MARKDOWN_START)
+            for manual_check, check_attributes in self.manual_checks.items():
+                output.write(
+                    CHECK_MARKDOWN_TEMPLATE.format(
+                        manual_check=manual_check, comment=check_attributes["comment"]
+                    )
+                )
+            output.write(MARKDOWN_END)
+
+
+def main():
+    ExportToMarkdown(
+        manual_checks_path=APP_VETTING_PATH, markdown_output_path=MARKDOWN_OUTPUT_PATH
+    )()
+
+
+if __name__ == "__main__":
+    main()

--- a/reporter.py
+++ b/reporter.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pprint import pprint
 
+
 def main(args):
     try:
         with open(args[0]) as f:
@@ -14,7 +15,7 @@ def main(args):
                         print("Warning List:")
                         for group in result["reports"][0]["groups"]:
                             for check in group["checks"]:
-                                if check["result"]=="warning":
+                                if check["result"] == "warning":
                                     for msg in check["messages"]:
                                         print(msg["message"])
                     pprint(result["summary"])
@@ -26,7 +27,7 @@ def main(args):
                     print("Failure List:")
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
-                            if check["result"]=="failure":
+                            if check["result"] == "failure":
                                 for msg in check["messages"]:
                                     print(msg["message"])
                     sys.exit(1)
@@ -42,4 +43,3 @@ def main(args):
 if __name__ == "__main__":
     print(sys.argv[1:])
     main(sys.argv[1:])
-    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+pyyaml==5.4.1
 splunk-appinspect==2.10.0


### PR DESCRIPTION
This is part of TART replacement INFRA-33842

* additional verification for manual tag run - comparing appinspect report with a static file created by the dev team
* README updated to cover new functionality
* pre-commit is added as part of this PR

Sample runs, showing different cases for implemented functionality:
 * empty .app-vetting.yaml file -https://github.com/splunk/splunk-add-on-for-carbon-black/runs/3951115763?check_suite_focus=true
 * .app-vetting.yaml with some missing checks and comments, also some old checks not required anymore - https://github.com/splunk/splunk-add-on-for-carbon-black/runs/3951252760?check_suite_focus=true
 * successful run - https://github.com/splunk/splunk-add-on-for-carbon-black/runs/3951404942?check_suite_focus=true