### PR TITLE
feat: update splunk-appinspect to 2.21.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,4 +27,5 @@ outputs:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.4.7"
+  image: "Dockerfile"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyyaml==5.4.1
-splunk-appinspect==2.13.3
+splunk-appinspect==2.21.0


### PR DESCRIPTION
This will not break anything, because it is set to `1.4` [here](https://github.com/splunk/addonfactory-workflow-addon-release/blob/4e5165e3e94266d3021105a58f6acd97bad44c78/.github/workflows/reusable-build-test-release.yml#L457).