### PR TITLE
feat: update splunk-appinspect to 2.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyyaml==5.4.1
-splunk-appinspect==2.13.3
+splunk-appinspect==2.14.1


### PR DESCRIPTION
Let's start with a 1 feature version update for splunk-appinspect and update it every week to see how it goes.

I think bumping the splunk-appinspect to the latest (2.21.0) may introduce too much work in one moment.