### PR TITLE
feat: individual support for manual checks and exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY export_to_markdown.py /
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 WORKDIR /github/workspace
-ENTRYPOINT ["bash", "-x", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Splunk AppInspect action
 
-This action runs Splunk's AppInspect CLI against a provided a directory of a Splunk App. 
-It fails if the result contains any failures.
+This action runs Splunk's AppInspect CLI against a provided directory of Splunk App. 
+It fails if the result contains any failures or manual checks are not vetted.
 
 The (json) result will be written to the file specified with [`result-file`](#result-file).
 This can be uploaded for later viewing to use in another step/job using [`actions/upload-artifact@v2`](https://github.com/marketplace/actions/upload-a-build-artifact).
@@ -29,15 +29,29 @@ Appinspect tags to exclude
 
 `required`: `false`
 
-### `app_vetting`
-Path to app vetting yaml file. Used only if `manual` in `included_tags`
+### `appinspect_manual_checks`
+Path to file which contains list of manual checks
 
-`default`: `.app-vetting.yaml`
+`required`: `false`
+`default`: `.appinspect.manualcheck`
+
+### `appinspect_expected_failures`
+Path to file which contains list of expected appinspect failures
+
+`required`: `false`
+`default`: `.appinspect.expect`
 
 ### `manual_check_markdown`
-Path for generated file with markdown for manual checks. Used only if `manual` in `included_tags`
+Path to generated file with markdown for manual checks
 
+`required`: `false`
 `default`: `manual_check_markdown.txt`
+
+### `appinspect_expected_failures`
+Path to generated file with markdown for expected appinspect failures
+
+`required`: `false`
+`default`: `expected_failure_markdown.txt`
 
 ## Outputs
 
@@ -45,19 +59,28 @@ Path for generated file with markdown for manual checks. Used only if `manual` i
 
 `pass|fail`
 
-## Using manual tag
-Running `appinspect-cli-action` with `manual` tag in `included_tags` detects checks that need to be verified manually and tests if all of them were already reviewed - if not the action will fail.
 ### Manual checks review
-To see checks to be verified inspect the `result_file` from `appinspect-cli-action` run with manual tag. Verify manual checks and mark them as reviewed by adding them one by one into `.app-vetting.yaml`, ex:
+To see checks to be verified, inspect the `result_file` from `appinspect-cli-action`. Verify manual checks and mark them as reviewed by adding them one by one into `.appinspect.manualcheck`, ex:
 ```yml
 name_of_manual_check_1:
   comment: 'your comment'
 name_of_manual_check_2:
   comment: 'your comment'
 ```
-please note that names of validated manual checks should be aligned with those from `result_file` and your comment can't be empty.
+Please note that names of validated manual checks should be aligned with those from `result_file` and your comment can't be empty.
+
+### Failure checks review 
+To mark Failures as expected, add them into `.appinspect.expect` with proper comment containing ticket id of ADDON/APPCERT project associated with the exception, ex:
+```yml
+name_of_exception_1:
+  comment: 'ADDON-123: your comment'
+name_of_exception_2:
+  comment: 'APPCERT-123: your comment'
+```
+Please note that your comment can't be empty, it must include ticket id of ADDON/APPCERT project associated with the exception and the names of exceptions should be aligned with those from `result_file`.
+
 ### Running the job
-When `appinspect-cli-action` is called with `manual` tag, it scans the package with Splunk's AppInspect CLI and searches for manual checks. In the next step, action compares `results_file` with `.app-vetting.yaml` if any check wasn't reviewed and isn't in `.app-vetting.yaml` then the job fails.
+When `appinspect-cli-action` is called, it scans the package with Splunk's AppInspect CLI. If there are any failures observed then action compares `results_file` with `.appinspect.expect`. If that failure isn't present in `appinspect.expect` or it does not contain an appropriate comment(containing ADDON/APPCERT ticket id associated with the exception) then the job fails with proper failure reason. In the next step, action compares `results_file` with `.appinspect.manualcheck`. If any manual check wasn't reviewed and isn't in `.appinspect.manualcheck` then the job fails.
 
 ## Example usage
 
@@ -66,20 +89,26 @@ When `appinspect-cli-action` is called with `manual` tag, it scans the package w
   with:
     app_path: 'test'
 ```
-### Downloading manual checks markdown
-If the comparison is successful then a markdown consisting a table with manual check names and comments is generated. It can be uploaded to artifacts.
+### Downloading markdowns
+If the comparison is successful then a markdown consisting a table with check names and comments is generated. It can be uploaded to artifacts.
 ```yml
 - uses: actions/checkout@v2
 - uses: splunk/appinspect-cli-action@v1.3
   with:
     app_path: 'test'
-    included_tags: manual
+    included_tags: cloud
     manual_check_markdown: manual_check_markdown.txt
+    expected_failure_markdown: expected_failure_markdown.txt
 - name: upload-manual-check-markodown
   uses: actions/upload-artifact@v2
   with:
     name: manual_check_markdown.txt
     path: manual_check_markdown.txt
+- name: upload-expected_failure-markodown
+  uses: actions/upload-artifact@v2
+  with:
+    name: expected_failure_markdown.txt
+    path: expected_failure_markdown.txt
 ```
 The markdown is ready to paste into confluence, by:
 `Edit -> Insert more content -> Markup`, change insert type to `Markdown` and paste the contents of the file.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ name_of_exception_2:
 Please note that your comment can't be empty, it must include ticket id of ADDON/APPCERT project associated with the exception and the names of exceptions should be aligned with those from `result_file`.
 
 ### Running the job
-When `appinspect-cli-action` is called, it scans the package with Splunk's AppInspect CLI. If there are any failures observed then action compares `results_file` with `.appinspect.expect`. If that failure isn't present in `appinspect.expect` or it does not contain an appropriate comment(containing ADDON/APPCERT ticket id associated with the exception) then the job fails with proper failure reason. In the next step, action compares `results_file` with `.appinspect.manualcheck`. If any manual check wasn't reviewed and isn't in `.appinspect.manualcheck` then the job fails.
+When `appinspect-cli-action` is called, it scans the package with Splunk's AppInspect CLI. If there are any failures observed then action compares `results_file` with `.appinspect.expect`. If that failure isn't present in `appinspect.expect` or it does not contain an appropriate comment(containing ADDON/APPCERT ticket id associated with the exception) then the job fails with proper failure reason. In the next step, action compares `results_file` with `.appinspect.manualcheck`. If any manual check wasn't reviewed by addon developer and isn't in `.appinspect.manualcheck` then the job fails.
 
 ## Example usage
 
@@ -96,7 +96,7 @@ If the comparison is successful then a markdown consisting a table with check na
 - uses: splunk/appinspect-cli-action@v1.3
   with:
     app_path: 'test'
-    included_tags: cloud
+    included_tags: {appinspect-tags-to-include}
     manual_check_markdown: manual_check_markdown.txt
     expected_failure_markdown: expected_failure_markdown.txt
 - name: upload-manual-check-markodown

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 # action.yml
 name: "Splunk AppInspect"
-description: "Run Splunk App insect on a Splunk app directory."
+description: "Run Splunk App inspect on a Splunk app directory."
 inputs:
   app_path:
-    description: "path to the application directory to be inspected"
+    description: "Path to the application directory to be inspected"
     default: build/splunkbase
   result_file:
     description: "json result file name"
@@ -15,11 +15,11 @@ inputs:
     description: "Tags to exclude"
     required: false
   appinspect_manual_checks:
-    description: "Path to app vetting yaml for manual checks"
+    description: "Path to file with list of manual checks"
     required: false
     default: ".appinspect.manualcheck"
   appinspect_expected_failures:
-    description: "Path to app vetting yaml for expected appinspect failures"
+    description: "Path to file with list of expected appinspect failures"
     required: false
     default: ".appinspect.expect"
   manual_check_markdown:

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   appinspect_manual_checks:
     description: "Path to app vetting yaml for manual checks"
     required: false
-    default: ".appinspect.manual.check"
+    default: ".appinspect.manualcheck"
   appinspect_expected_failures:
     description: "Path to app vetting yaml for expected appinspect failures"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   app_vetting_expected_failures:
     description: "Path to app vetting yaml file for expected failures"
     required: false
-    default: ".appinspect.expected.failure.yaml"
+    default: ".appinspect.expect.yaml"
   manual_check_markdown:
     description: "Path for generated file with markdown for manual checks"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,11 @@ inputs:
     required: false
     default: ".appinspect.expect"
   manual_check_markdown:
-    description: "Path to generated file with markdown for manual checks"
+    description: "Path for generated file with markdown for manual checks"
     required: false
     default: "manual_check_markdown.txt"
   expected_failure_markdown:
-    description: "Path to generated file with markdown for expected appinspect failures"
+    description: "Path for generated file with markdown for expected appinspect failures"
     required: false
     default: "expected_failure_markdown.txt"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,14 @@ inputs:
   excluded_tags:
     description: "Tags to exclude"
     required: false
-  app_vetting:
-    description: "Path to app vetting yaml file"
+  app_vetting_manual_checks:
+    description: "Path to app vetting yaml file for manual checks"
     required: false
-    default: ".app-vetting.yaml"
+    default: ".app-vetting-manual-checks.yaml"
+  app_vetting_expected_failures:
+    description: "Path to app vetting yaml file for expected failures"
+    required: false
+    default: ".app-vetting-expected-failure.yaml"
   manual_check_markdown:
     description: "Path for generated file with markdown for manual checks and exceptions"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -27,4 +27,4 @@ outputs:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.5.0"
+  image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -14,20 +14,20 @@ inputs:
   excluded_tags:
     description: "Tags to exclude"
     required: false
-  app_vetting_manual_checks:
-    description: "Path to app vetting yaml file for manual checks"
+  appinspect_manual_checks:
+    description: "Path to app vetting yaml for manual checks"
     required: false
-    default: ".app-vetting.yaml"
-  app_vetting_expected_failures:
-    description: "Path to app vetting yaml file for expected failures"
+    default: ".appinspect.manual.check"
+  appinspect_expected_failures:
+    description: "Path to app vetting yaml for expected appinspect failures"
     required: false
-    default: ".appinspect.expect.yaml"
+    default: ".appinspect.expect"
   manual_check_markdown:
-    description: "Path for generated file with markdown for manual checks"
+    description: "Path to generated file with markdown for manual checks"
     required: false
     default: "manual_check_markdown.txt"
   expected_failure_markdown:
-    description: "Path for generated file with markdown for exceptions"
+    description: "Path to generated file with markdown for exceptions"
     required: false
     default: "expected_failure_markdown.txt"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
     description: "Tags to exclude"
     required: false
   appinspect_manual_checks:
-    description: "Path to file with list of manual checks"
+    description: "Path to file which contains list of manual checks"
     required: false
     default: ".appinspect.manualcheck"
   appinspect_expected_failures:
-    description: "Path to file with list of expected appinspect failures"
+    description: "Path to file which contains list of expected appinspect failures"
     required: false
     default: ".appinspect.expect"
   manual_check_markdown:
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: "manual_check_markdown.txt"
   expected_failure_markdown:
-    description: "Path to generated file with markdown for exceptions"
+    description: "Path to generated file with markdown for expected appinspect failures"
     required: false
     default: "expected_failure_markdown.txt"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   app_vetting_expected_failures:
     description: "Path to app vetting yaml file for expected failures"
     required: false
-    default: ".app-vetting-expected-failure.yaml"
+    default: ".appinspect.expected.failure.yaml"
   manual_check_markdown:
     description: "Path for generated file with markdown for manual checks"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,15 +17,19 @@ inputs:
   app_vetting_manual_checks:
     description: "Path to app vetting yaml file for manual checks"
     required: false
-    default: ".app-vetting-manual-checks.yaml"
+    default: ".app-vetting.yaml"
   app_vetting_expected_failures:
     description: "Path to app vetting yaml file for expected failures"
     required: false
     default: ".app-vetting-expected-failure.yaml"
   manual_check_markdown:
-    description: "Path for generated file with markdown for manual checks and exceptions"
+    description: "Path for generated file with markdown for manual checks"
     required: false
     default: "manual_check_markdown.txt"
+  expected_failure_markdown:
+    description: "Path for generated file with markdown for exceptions"
+    required: false
+    default: "expected_failure_markdown.txt"
 outputs:
   status:
     description: "value is success/fail based on app inspect result"

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -105,9 +105,9 @@ def compare(
             print(
             f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper tickiet id. Below checks are not commented with required tickiet id"
             f" {vetting_file}:{BCOLORS.ENDC}"
-            for check in checks_with_no_id:
-                print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
         )
+        for check in checks_with_no_id:
+            print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
 
     return new_checks + not_commented + checks_with_no_id
 

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -101,6 +101,11 @@ def compare(
     checks_with_no_id = []
     if check_type=="failure":
         checks_with_no_id = validate_comment(vetting_data)
+        if checks_with_no_id:
+            print(
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper tickiet id. Below checks are not commented with required tickiet id"
+            f" {vetting_file}:{BCOLORS.ENDC}"
+        )
 
     return new_checks + not_commented + checks_with_no_id
 

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -26,7 +26,7 @@ class BCOLORS:
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
 
-def validate_comment(vetting_dat):
+def validate_comment(vetting_data):
     checks = []
     ticket_id=re.compile(r"((ADDON|APPCERT)-[0-9]+)")
     for check, info in vetting_data.items():

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -103,7 +103,7 @@ def compare(
         checks_with_no_id = validate_comment(vetting_data)
         if checks_with_no_id:
             print(
-            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper ticket id. Below checks are not commented with required ticket id"
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All {check_type} checks require comment with proper ticket id. Below checks are not commented with required ticket id"
             f" {vetting_file}:{BCOLORS.ENDC}"
         )
         for check in checks_with_no_id:

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 import yaml
+import re
 
 print(
     f"{os.path.basename(__file__)} script was called with parameters: {' '.join(sys.argv[1:])}"

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -37,16 +37,16 @@ def validate_comment(vetting_data):
 
 def compare(
     check_type: str,
-    vetting_file: str = ".app-vetting.yaml",
+    vetting_file: str = ".appinspect.manualcheck",
     appinspect_result_file: str = "appinspect_output.json",
 ) -> List[str]:
     """
     Compares checks from vetting file and appinspect result file. A lot prints are added to make it
     easier for users to create proper vetting_file and understand errors
 
-    :param vetting_file: path to yaml file with verified manual checks
+    :param vetting_file: path to file with varified list of checks
     :param appinspect_result_file: path to Splunk's AppInspect CLI result file
-    :return: list of non matching tests between vetting_file and appinspect_result_file or not commented ones
+    :return: list of non matching tests between vetting_file and appinspect_result_file or not commented ones or checks with inappropriate comment
     """
     if not os.path.isfile(appinspect_result_file):
         raise FileNotFoundError(
@@ -116,20 +116,20 @@ def get_checks_from_appinspect_result(
     path: str, result: str = "manual_check"
 ) -> List[str]:
     """
-    Returns manual checks from appinspect json result file
+    Returns checks from appinspect json result file
 
     :param path: path to json result file
     :return: list of checks in string format
     """
-    manual_checks = []
+    checks = []
     with open(path) as f:
         appinspect_results = json.load(f)
         for report in appinspect_results["reports"]:
             for group in report["groups"]:
                 for check in group["checks"]:
                     if check["result"] == result:
-                        manual_checks.append(check["name"])
-    return manual_checks
+                        checks.append(check["name"])
+    return checks
 
 
 def main():

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -103,7 +103,7 @@ def compare(
         checks_with_no_id = validate_comment(vetting_data)
         if checks_with_no_id:
             print(
-            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper tickiet id. Below checks are not commented with required tickiet id"
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper ticket id. Below checks are not commented with required ticket id"
             f" {vetting_file}:{BCOLORS.ENDC}"
         )
         for check in checks_with_no_id:

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -28,7 +28,7 @@ class BCOLORS:
 
 def validate_comment(vetting_data):
     checks = []
-    ticket_id=re.compile(r"((ADDON|APPCERT)-[0-9]+)")
+    ticket_id=re.compile(r"((?i)(ADDON|APPCERT)-[0-9]+)")
     for check, info in vetting_data.items():
         if not re.search(ticket_id,info.get("comment")):
             checks.append(check)
@@ -103,11 +103,11 @@ def compare(
         checks_with_no_id = validate_comment(vetting_data)
         if checks_with_no_id:
             print(
-            f"{BCOLORS.FAIL}{BCOLORS.BOLD}All {check_type} checks require comment with proper ticket id. Below checks are not commented with required ticket id"
+            f"{BCOLORS.FAIL}{BCOLORS.BOLD}There are some checks which require comment with proper ticket id in {vetting_file}. Below checks are not commented with required ticket id"
             f" {vetting_file}:{BCOLORS.ENDC}"
         )
-        for check in checks_with_no_id:
-            print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
+            for check in checks_with_no_id:
+                print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
 
     return new_checks + not_commented + checks_with_no_id
 

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -25,6 +25,14 @@ class BCOLORS:
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
 
+def validate_comment(vetting_dat):
+    checks = []
+    ticket_id=re.compile(r"((ADDON|APPCERT)-[0-9]+)")
+    for check, info in vetting_data.items():
+        if not re.search(ticket_id,info.get("comment")):
+            checks.append(check)
+    return checks
+
 
 def compare(
     check_type: str,
@@ -89,8 +97,11 @@ def compare(
         print(
             f"{BCOLORS.FAIL}{BCOLORS.BOLD}Please see appinspect report for more detailed description about {check_type} checks and review them accordingly.{BCOLORS.ENDC}"
         )
+    checks_with_no_id = []
+    if check_type=="failure":
+        checks_with_no_id = validate_comment(vetting_data)
 
-    return new_checks + not_commented
+    return new_checks + not_commented + checks_with_no_id
 
 
 def get_checks_from_appinspect_result(

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -105,6 +105,8 @@ def compare(
             print(
             f"{BCOLORS.FAIL}{BCOLORS.BOLD}All verified {check_type} checks require comment with proper tickiet id. Below checks are not commented with required tickiet id"
             f" {vetting_file}:{BCOLORS.ENDC}"
+            for check in checks_with_no_id:
+                print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
         )
 
     return new_checks + not_commented + checks_with_no_id

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,6 +59,7 @@ if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code_failure == 0 ] && 
   echo "successful comparison, generating markdown"
   echo "/export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
   python3 /export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
+  python3 /export_to_markdown.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_MANUAL_CHECK_MARKDOWN
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,22 +45,22 @@ echo "::endgroup::"
 exit_code_failure=$exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
-  python3 /compare_checks.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_RESULT_FILE "failure"
+  python3 /compare_checks.py $INPUT_APPINSPECT_EXPECTED_FAILURES $INPUT_RESULT_FILE "failure"
   exit_code_failure=$?
   echo "::endgroup::"
 fi
 
 echo "::group::manual_checks"
-python3 /compare_checks.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_RESULT_FILE "manual_check"
+python3 /compare_checks.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_RESULT_FILE "manual_check"
 exit_code_manual_check=$?
 echo "::endgroup::"
 
 if [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
   echo "::group::generate_markdown"
   echo "successful comparison, generating markdown"
-  echo "/export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
-  python3 /export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
-  python3 /export_to_markdown.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_EXPECTED_FAILURE_MARKDOWN
+  echo "/export_to_markdown.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
+  python3 /export_to_markdown.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
+  python3 /export_to_markdown.py $INPUT_APPINSPECT_EXPECTED_FAILURES $INPUT_EXPECTED_FAILURE_MARKDOWN
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,8 +32,8 @@ if [ ! -z $INPUT_EXCLUDED_TAGS ]; then EXCLUDED_TAGS="--excluded-tags ${INPUT_EX
 
 echo "::group::appinspect"
 rm -f $INPUT_RESULT_FILE || true 1>/dev/null
-echo running: splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
-splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
+echo running: splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test --included-tags cloud --included-tags manual $EXCLUDED_TAGS
+splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test --included-tags cloud --included-tags manual $EXCLUDED_TAGS
 if [ ! -f $INPUT_RESULT_FILE ]; then echo no result file; exit 1; fi
 echo "::endgroup::"
 
@@ -59,7 +59,7 @@ if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code_failure == 0 ] && 
   echo "successful comparison, generating markdown"
   echo "/export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
   python3 /export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
-  python3 /export_to_markdown.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_MANUAL_CHECK_MARKDOWN
+  python3 /export_to_markdown.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_EXPECTED_FAILURE_MARKDOWN
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ echo "::group::reporter"
 python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
-exit_code_failure=exit_code
+exit_code_failure=$exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_RESULT_FILE "failure"
@@ -54,16 +54,12 @@ python3 /compare_checks.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_RESULT_FILE "
 exit_code_manual_check=$?
 echo "::endgroup::"
 
-# if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code == 0 ]; then
-#   echo "::group::manual_checks"
-#   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
-#   exit_code=$?
-#   if [ $exit_code == 0 ]; then
-#     echo "successful comparison, generating markdown"
-#     echo "/export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN"
-#     python3 /export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN
-#   fi
-#   echo "::endgroup::"
-# fi
+if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
+  echo "::group::generate_markdown"
+  echo "successful comparison, generating markdown"
+  echo "/export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
+  python3 /export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
+  echo "::endgroup::"
+fi
 
-! (($exit_code_failure || $exit_code_manual_check))
+exit "$(($exit_code_failure || $exit_code_manual_check))"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,11 +42,11 @@ python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
 
+python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
+exit_code=$?
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "failure"
-  exit_code=$?
-  python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
   exit_code=$?
   echo "::endgroup::"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,13 +44,13 @@ echo "::endgroup::"
 exit_code_failure=exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
-  python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "failure"
+  python3 /compare_checks.py $INPUT_APP_VETTING_EXPECTED_FAILURES $INPUT_RESULT_FILE "failure"
   exit_code_failure=$?
   echo "::endgroup::"
 fi
 
 echo "::group::manual_checks"
-python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
+python3 /compare_checks.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_RESULT_FILE "manual_check"
 exit_code_manual_check=$?
 echo "::endgroup::"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,8 +32,8 @@ if [ ! -z $INPUT_EXCLUDED_TAGS ]; then EXCLUDED_TAGS="--excluded-tags ${INPUT_EX
 
 echo "::group::appinspect"
 rm -f $INPUT_RESULT_FILE || true 1>/dev/null
-echo running: splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test --included-tags cloud --included-tags manual $EXCLUDED_TAGS
-splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test --included-tags cloud --included-tags manual $EXCLUDED_TAGS
+echo running: splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
+splunk-appinspect inspect $SCAN --output-file $INPUT_RESULT_FILE --mode test $INCLUDED_TAGS $EXCLUDED_TAGS
 if [ ! -f $INPUT_RESULT_FILE ]; then echo no result file; exit 1; fi
 echo "::endgroup::"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ echo "::group::reporter"
 python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
-
+exit_code_failure=exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "failure"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,6 @@ echo "::endgroup::"
 if [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
   echo "::group::generate_markdown"
   echo "successful comparison, generating markdown"
-  echo "/export_to_markdown.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"
   python3 /export_to_markdown.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
   python3 /export_to_markdown.py $INPUT_APPINSPECT_EXPECTED_FAILURES $INPUT_EXPECTED_FAILURE_MARKDOWN
   echo "::endgroup::"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,7 @@ echo "::group::reporter"
 python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
+
 exit_code_failure=$exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,8 @@ if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "failure"
   exit_code=$?
+  python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
+  exit_code=$?
   echo "::endgroup::"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,11 +42,11 @@ python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
 
-exit_code_failure=$exit_code
+exit_code_failure_check=$exit_code
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APPINSPECT_EXPECTED_FAILURES $INPUT_RESULT_FILE "failure"
-  exit_code_failure=$?
+  exit_code_failure_check=$?
   echo "::endgroup::"
 fi
 
@@ -55,7 +55,7 @@ python3 /compare_checks.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_RESULT_FILE "m
 exit_code_manual_check=$?
 echo "::endgroup::"
 
-if [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
+if [ $exit_code_failure_check == 0 ] && [ $exit_code_manual_check == 0 ] ; then
   echo "::group::generate_markdown"
   echo "successful comparison, generating markdown"
   python3 /export_to_markdown.py $INPUT_APPINSPECT_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN
@@ -63,4 +63,4 @@ if [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
   echo "::endgroup::"
 fi
 
-exit "$(($exit_code_failure || $exit_code_manual_check))"
+exit "$(($exit_code_failure_check || $exit_code_manual_check))"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,25 +42,28 @@ python3 /reporter.py $INPUT_RESULT_FILE
 exit_code=$?
 echo "::endgroup::"
 
-python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
-exit_code=$?
 if [ $exit_code != 0 ]; then
   echo "::group::failure_checks"
   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "failure"
-  exit_code=$?
+  exit_code_failure=$?
   echo "::endgroup::"
 fi
 
-if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code == 0 ]; then
-  echo "::group::manual_checks"
-  python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
-  exit_code=$?
-  if [ $exit_code == 0 ]; then
-    echo "successful comparison, generating markdown"
-    echo "/export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN"
-    python3 /export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN
-  fi
-  echo "::endgroup::"
-fi
+echo "::group::manual_checks"
+python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
+exit_code_manual_check=$?
+echo "::endgroup::"
 
-exit "$exit_code"
+# if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code == 0 ]; then
+#   echo "::group::manual_checks"
+#   python3 /compare_checks.py $INPUT_APP_VETTING $INPUT_RESULT_FILE "manual_check"
+#   exit_code=$?
+#   if [ $exit_code == 0 ]; then
+#     echo "successful comparison, generating markdown"
+#     echo "/export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN"
+#     python3 /export_to_markdown.py $INPUT_APP_VETTING $INPUT_MANUAL_CHECK_MARKDOWN
+#   fi
+#   echo "::endgroup::"
+# fi
+
+! (($exit_code_failure || $exit_code_manual_check))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ python3 /compare_checks.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_RESULT_FILE "
 exit_code_manual_check=$?
 echo "::endgroup::"
 
-if [[ "$INPUT_INCLUDED_TAGS" == *"manual"* ]] && [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
+if [ $exit_code_failure == 0 ] && [ $exit_code_manual_check == 0 ] ; then
   echo "::group::generate_markdown"
   echo "successful comparison, generating markdown"
   echo "/export_to_markdown.py $INPUT_APP_VETTING_MANUAL_CHECKS $INPUT_MANUAL_CHECK_MARKDOWN"

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -46,7 +46,7 @@ class ExportToMarkdown:
             self.manual_checks = {}
 
     def _create_output_markup(self):
-        with open(self.markdown_output_path, "a") as output:
+        with open(self.markdown_output_path, "w") as output:
             output.write(MARKDOWN_START)
             for manual_check, check_attributes in self.manual_checks.items():
                 output.write(

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -46,7 +46,7 @@ class ExportToMarkdown:
             self.manual_checks = {}
 
     def _create_output_markup(self):
-        with open(self.markdown_output_path, "w") as output:
+        with open(self.markdown_output_path, "a") as output:
             output.write(MARKDOWN_START)
             for manual_check, check_attributes in self.manual_checks.items():
                 output.write(

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -9,7 +9,7 @@ MARKDOWN_START = """<div class=3D"table-wrap">
 <table class=3D"confluenceTable">
 <tbody>
 <tr>
-<th class=3D"confluenceTh">manual check</th>
+<th class=3D"confluenceTh">check</th>
 <th class=3D"confluenceTh">comment</th>
 </tr>
 """

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -15,7 +15,7 @@ MARKDOWN_START = """<div class=3D"table-wrap">
 """
 
 CHECK_MARKDOWN_TEMPLATE = """<tr>
-<td class=3D"confluenceTh">{manual_check}</th>
+<td class=3D"confluenceTh">{check}</th>
 <td class=3D"confluenceTh">{comment}</th>
 </tr>
 """
@@ -30,28 +30,28 @@ class ExportToMarkdown:
     Based on app vetting file generates file with markdown consisting names of validated checks and comments.
     """
 
-    def __init__(self, manual_checks_path, markdown_output_path):
-        self.manual_checks_path = manual_checks_path
+    def __init__(self, checks_path, markdown_output_path):
+        self.checks_path = checks_path
         self.markdown_output_path = markdown_output_path
-        self.manual_checks = None
+        self.checks = None
 
     def __call__(self):
-        self._load_manual_checks()
+        self._load_checks()
         self._create_output_markup()
 
-    def _load_manual_checks(self):
-        with open(self.manual_checks_path) as vetting_data:
-            self.manual_checks = yaml.safe_load(vetting_data)
-        if self.manual_checks is None:
-            self.manual_checks = {}
+    def _load_checks(self):
+        with open(self.checks_path) as vetting_data:
+            self.checks = yaml.safe_load(vetting_data)
+        if self.checks is None:
+            self.checks = {}
 
     def _create_output_markup(self):
         with open(self.markdown_output_path, "w") as output:
             output.write(MARKDOWN_START)
-            for manual_check, check_attributes in self.manual_checks.items():
+            for check, check_attributes in self.checks.items():
                 output.write(
                     CHECK_MARKDOWN_TEMPLATE.format(
-                        manual_check=manual_check, comment=check_attributes["comment"]
+                        check=check, comment=check_attributes["comment"]
                     )
                 )
             output.write(MARKDOWN_END)
@@ -59,7 +59,7 @@ class ExportToMarkdown:
 
 def main():
     ExportToMarkdown(
-        manual_checks_path=APP_VETTING_PATH, markdown_output_path=MARKDOWN_OUTPUT_PATH
+        checks_path=APP_VETTING_PATH, markdown_output_path=MARKDOWN_OUTPUT_PATH
     )()
 
 

--- a/reporter.py
+++ b/reporter.py
@@ -43,7 +43,7 @@ def main(args):
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
                             if check["result"] == "failure":
-                                print(f'{BCOLORS.FAIL}check["name"]')
+                                print(f'{BCOLORS.FAIL} {check["name"]}')
                                 for msg in check["messages"]:
                                     print(msg["message"])
                     sys.exit(1)

--- a/reporter.py
+++ b/reporter.py
@@ -7,6 +7,7 @@ class BCOLORS:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
     OKCYAN = "\033[96m"
+    BOLD = "\033[1m"
 
 def format_result(result):
     header = result.keys()
@@ -29,7 +30,8 @@ def main(args):
                                 if check["result"] == "warning":
                                     for msg in check["messages"]:
                                         print(msg["message"])
-                    pprint(result["summary"])
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    format_result(result["summary"])
                     print("::set-output name=status::pass")
                 else:
                     print(f"App Inspect returned {failures} failures.")

--- a/reporter.py
+++ b/reporter.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import tabulate
+import os
 from pprint import pprint
 
 class BCOLORS:
@@ -36,9 +37,13 @@ def main(args):
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])
                     # print("::set-output name=status::pass")
+                    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                        print("status=pass", file=fh)
                 else:
                     print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
                     # print("::set-output name=status::fail")
+                    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                        print("status=fail", file=fh)
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:')
@@ -52,6 +57,8 @@ def main(args):
             else:
                 print("Unexpected JSON format")
                 # print("::set-output name=status::fail")
+                with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                    print("status=fail", file=fh)
                 sys.exit(1)
     except Exception as e:
         print(f"An error occurred {str(e)}")

--- a/reporter.py
+++ b/reporter.py
@@ -35,10 +35,10 @@ def main(args):
                                         print(msg["message"])
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])
-                    print("::set-output name=status::pass")
+                    # print("::set-output name=status::pass")
                 else:
                     print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
-                    print("::set-output name=status::fail")
+                    # print("::set-output name=status::fail")
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:')
@@ -51,7 +51,7 @@ def main(args):
                     sys.exit(1)
             else:
                 print("Unexpected JSON format")
-                print("::set-output name=status::fail")
+                # print("::set-output name=status::fail")
                 sys.exit(1)
     except Exception as e:
         print(f"An error occurred {str(e)}")

--- a/reporter.py
+++ b/reporter.py
@@ -1,6 +1,17 @@
 import json
 import sys
+import tabulate
 from pprint import pprint
+
+class BCOLORS:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+
+def format_result(result):
+    header = result.keys()
+    row = [[result[x] for x in test]]
+    print(tabulate.tabulate(row, header))   
 
 
 def main(args):
@@ -28,6 +39,7 @@ def main(args):
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
                             if check["result"] == "failure":
+                                print(check["name"])
                                 for msg in check["messages"]:
                                     print(msg["message"])
                     sys.exit(1)

--- a/reporter.py
+++ b/reporter.py
@@ -13,10 +13,9 @@ class BCOLORS:
     BOLD = "\033[1m"
 
 def format_result(result):
-    header = result.keys()
-    row = [[result[x] for x in result]]
-    print(tabulate.tabulate(row, header))   
-
+    restructured_result = ["success","manual_check","not_applicable","skipped","warning","error","failure"]
+    row = [[result[x] for x in restructured_result]]
+    print(tabulate.tabulate(row, restructured_result))
 
 def main(args):
     try:

--- a/reporter.py
+++ b/reporter.py
@@ -7,6 +7,8 @@ class BCOLORS:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
     OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
     FAIL = "\033[91m"
     BOLD = "\033[1m"
 
@@ -23,12 +25,13 @@ def main(args):
             if "summary" in result and "failure" in result["summary"]:
                 failures = result["summary"]["failure"]
                 if failures == 0:
-                    print("App Inspect Passed!")
+                    print(f"{BCOLORS.BOLD}{BCOLORS.OKGREEN}App Inspect Passed!")
                     if "warning" in result["summary"] and result["summary"]["warning"]:
-                        print("Warning List:")
+                        print(f"{BCOLORS.OKBLUE}Warning List:")
                         for group in result["reports"][0]["groups"]:
                             for check in group["checks"]:
                                 if check["result"] == "warning":
+                                    print(f'{BCOLORS.WARNING} {check["name"]}')
                                     for msg in check["messages"]:
                                         print(msg["message"])
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')

--- a/reporter.py
+++ b/reporter.py
@@ -1,8 +1,7 @@
 import json
+import os
 import sys
 import tabulate
-import os
-from pprint import pprint
 
 class BCOLORS:
     HEADER = "\033[95m"

--- a/reporter.py
+++ b/reporter.py
@@ -36,12 +36,10 @@ def main(args):
                                         print(msg["message"])
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])
-                    # print("::set-output name=status::pass")
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=pass", file=fh)
                 else:
                     print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
-                    # print("::set-output name=status::fail")
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=fail", file=fh)
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
@@ -56,7 +54,6 @@ def main(args):
                     sys.exit(1)
             else:
                 print("Unexpected JSON format")
-                # print("::set-output name=status::fail")
                 with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                     print("status=fail", file=fh)
                 sys.exit(1)

--- a/reporter.py
+++ b/reporter.py
@@ -7,11 +7,12 @@ class BCOLORS:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
     OKCYAN = "\033[96m"
+    FAIL = "\033[91m"
     BOLD = "\033[1m"
 
 def format_result(result):
     header = result.keys()
-    row = [[result[x] for x in test]]
+    row = [[result[x] for x in result]]
     print(tabulate.tabulate(row, header))   
 
 
@@ -36,12 +37,13 @@ def main(args):
                 else:
                     print(f"App Inspect returned {failures} failures.")
                     print("::set-output name=status::fail")
-                    pprint(result["summary"])
-                    print("Failure List:")
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    format_result(result["summary"])
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:')
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
                             if check["result"] == "failure":
-                                print(check["name"])
+                                print(f'{BCOLORS.FAIL}check["name"]')
                                 for msg in check["messages"]:
                                     print(msg["message"])
                     sys.exit(1)

--- a/reporter.py
+++ b/reporter.py
@@ -38,7 +38,7 @@ def main(args):
                     format_result(result["summary"])
                     print("::set-output name=status::pass")
                 else:
-                    print(f"App Inspect returned {failures} failures.")
+                    print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
                     print("::set-output name=status::fail")
                     print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
                     format_result(result["summary"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml==5.4.1
 splunk-appinspect==2.30.0
+tabulate==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyyaml==5.4.1
-splunk-appinspect==2.14.1
+splunk-appinspect==2.30.0


### PR DESCRIPTION
Following changes have been done as part of this PR

- Instead of maintaining a single file for manual checks and exception, now action will use two individual files, .appinspect.manual.check and .appinspect.expect
- Added a validation to check all the expected checks which are mentioned in .appinspect.expect must contain a ticket id starting with ADDON/APPCERT
- Removed condition for checking manual_check is vetted only when included tag is manual, action will check if manual_check is vetted or not for all the tags
- Upgraded Appinspect version to the latest available 2.30.0
- Made enhancements to better represent test report in CI stage for easy understanding