### PR TITLE
feat: individual support for manual checks and exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY export_to_markdown.py /
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 WORKDIR /github/workspace
-ENTRYPOINT ["bash", "-x", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 # action.yml
 name: "Splunk AppInspect"
-description: "Run Splunk App insect on a Splunk app directory."
+description: "Run Splunk App inspect on a Splunk app directory."
 inputs:
   app_path:
-    description: "path to the application directory to be inspected"
+    description: "Path to the application directory to be inspected"
     default: build/splunkbase
   result_file:
     description: "json result file name"
@@ -14,17 +14,25 @@ inputs:
   excluded_tags:
     description: "Tags to exclude"
     required: false
-  app_vetting:
-    description: "Path to app vetting yaml file"
+  appinspect_manual_checks:
+    description: "Path to file which contains list of manual checks"
     required: false
-    default: ".app-vetting.yaml"
+    default: ".appinspect.manualcheck.yaml"
+  appinspect_expected_failures:
+    description: "Path to file which contains list of expected appinspect failures"
+    required: false
+    default: ".appinspect.expect.yaml"
   manual_check_markdown:
-    description: "Path for generated file with markdown for manual checks and exceptions"
+    description: "Path for generated file with markdown for manual checks"
     required: false
     default: "manual_check_markdown.txt"
+  expected_failure_markdown:
+    description: "Path for generated file with markdown for expected appinspect failures"
+    required: false
+    default: "expected_failure_markdown.txt"
 outputs:
   status:
     description: "value is success/fail based on app inspect result"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/appinspect-cli-action/appinspect-cli-action:v1.5.1"
+  image: "Dockerfile"

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -1,10 +1,10 @@
 import json
 import os
+import re
 import sys
 from typing import List
 
 import yaml
-import re
 
 print(
     f"{os.path.basename(__file__)} script was called with parameters: {' '.join(sys.argv[1:])}"
@@ -28,9 +28,9 @@ class BCOLORS:
 
 def validate_comment(vetting_data):
     checks = []
-    ticket_id=re.compile(r"((?i)(ADDON|APPCERT)-[0-9]+)")
+    ticket_id = re.compile(r"((?i)(ADDON|APPCERT)-[0-9]+)")
     for check, info in vetting_data.items():
-        if not re.search(ticket_id,info.get("comment")):
+        if not re.search(ticket_id, info.get("comment")):
             checks.append(check)
     return checks
 
@@ -99,12 +99,12 @@ def compare(
             f"{BCOLORS.FAIL}{BCOLORS.BOLD}Please see appinspect report for more detailed description about {check_type} checks and review them accordingly.{BCOLORS.ENDC}"
         )
     checks_with_no_id = []
-    if check_type=="failure":
+    if check_type == "failure":
         checks_with_no_id = validate_comment(vetting_data)
         if checks_with_no_id:
             print(
-            f"{BCOLORS.FAIL}{BCOLORS.BOLD}There are some checks which require comment with proper ticket id in {vetting_file}. Below checks are not commented with required ticket id"
-            f" {vetting_file}:{BCOLORS.ENDC}"
+                f"{BCOLORS.FAIL}{BCOLORS.BOLD}There are some checks which require comment with proper ticket id in {vetting_file}. Below checks are not commented with required ticket id in"
+                f" {vetting_file}:{BCOLORS.ENDC}"
         )
             for check in checks_with_no_id:
                 print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")

--- a/compare_checks.py
+++ b/compare_checks.py
@@ -26,6 +26,7 @@ class BCOLORS:
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
 
+
 def validate_comment(vetting_data):
     checks = []
     ticket_id = re.compile(r"((?i)(ADDON|APPCERT)-[0-9]+)")
@@ -105,7 +106,7 @@ def compare(
             print(
                 f"{BCOLORS.FAIL}{BCOLORS.BOLD}There are some checks which require comment with proper ticket id in {vetting_file}. Below checks are not commented with required ticket id in"
                 f" {vetting_file}:{BCOLORS.ENDC}"
-        )
+            )
             for check in checks_with_no_id:
                 print(f"{BCOLORS.FAIL}{BCOLORS.BOLD}\t{check}{BCOLORS.ENDC}")
 

--- a/export_to_markdown.py
+++ b/export_to_markdown.py
@@ -9,13 +9,13 @@ MARKDOWN_START = """<div class=3D"table-wrap">
 <table class=3D"confluenceTable">
 <tbody>
 <tr>
-<th class=3D"confluenceTh">manual check</th>
+<th class=3D"confluenceTh">check</th>
 <th class=3D"confluenceTh">comment</th>
 </tr>
 """
 
 CHECK_MARKDOWN_TEMPLATE = """<tr>
-<td class=3D"confluenceTh">{manual_check}</th>
+<td class=3D"confluenceTh">{check}</th>
 <td class=3D"confluenceTh">{comment}</th>
 </tr>
 """
@@ -30,28 +30,28 @@ class ExportToMarkdown:
     Based on app vetting file generates file with markdown consisting names of validated checks and comments.
     """
 
-    def __init__(self, manual_checks_path, markdown_output_path):
-        self.manual_checks_path = manual_checks_path
+    def __init__(self, checks_path, markdown_output_path):
+        self.checks_path = checks_path
         self.markdown_output_path = markdown_output_path
-        self.manual_checks = None
+        self.checks = None
 
     def __call__(self):
-        self._load_manual_checks()
+        self._load_checks()
         self._create_output_markup()
 
-    def _load_manual_checks(self):
-        with open(self.manual_checks_path) as vetting_data:
-            self.manual_checks = yaml.safe_load(vetting_data)
-        if self.manual_checks is None:
-            self.manual_checks = {}
+    def _load_checks(self):
+        with open(self.checks_path) as vetting_data:
+            self.checks = yaml.safe_load(vetting_data)
+        if self.checks is None:
+            self.checks = {}
 
     def _create_output_markup(self):
         with open(self.markdown_output_path, "w") as output:
             output.write(MARKDOWN_START)
-            for manual_check, check_attributes in self.manual_checks.items():
+            for check, check_attributes in self.checks.items():
                 output.write(
                     CHECK_MARKDOWN_TEMPLATE.format(
-                        manual_check=manual_check, comment=check_attributes["comment"]
+                        check=check, comment=check_attributes["comment"]
                     )
                 )
             output.write(MARKDOWN_END)
@@ -59,7 +59,7 @@ class ExportToMarkdown:
 
 def main():
     ExportToMarkdown(
-        manual_checks_path=APP_VETTING_PATH, markdown_output_path=MARKDOWN_OUTPUT_PATH
+        checks_path=APP_VETTING_PATH, markdown_output_path=MARKDOWN_OUTPUT_PATH
     )()
 
 

--- a/reporter.py
+++ b/reporter.py
@@ -13,7 +13,15 @@ class BCOLORS:
     BOLD = "\033[1m"
 
 def format_result(result):
-    restructured_result = ["success","manual_check","not_applicable","skipped","warning","error","failure"]
+    restructured_result = [
+        "success",
+        "manual_check",
+        "not_applicable",
+        "skipped",
+        "warning",
+        "error",
+        "failure"
+    ]
     row = [[result[x] for x in restructured_result]]
     print(tabulate.tabulate(row, restructured_result))
 
@@ -33,17 +41,19 @@ def main(args):
                                     print(f'{BCOLORS.WARNING} {check["name"]}')
                                     for msg in check["messages"]:
                                         print(msg["message"])
-                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    print(f"{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY")
                     format_result(result["summary"])
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=pass", file=fh)
                 else:
-                    print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
+                    print(
+                        f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures."
+                    )
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=fail", file=fh)
-                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    print(f"{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY")
                     format_result(result["summary"])
-                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:')
+                    print(f"{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:")
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
                             if check["result"] == "failure":

--- a/reporter.py
+++ b/reporter.py
@@ -1,8 +1,21 @@
 import json
 import os
 import sys
-from pprint import pprint
+import tabulate
 
+class BCOLORS:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    BOLD = "\033[1m"
+
+def format_result(result):
+    restructured_result = ["success","manual_check","not_applicable","skipped","warning","error","failure"]
+    row = [[result[x] for x in restructured_result]]
+    print(tabulate.tabulate(row, restructured_result))
 
 def main(args):
     try:
@@ -11,26 +24,30 @@ def main(args):
             if "summary" in result and "failure" in result["summary"]:
                 failures = result["summary"]["failure"]
                 if failures == 0:
-                    print("App Inspect Passed!")
+                    print(f"{BCOLORS.BOLD}{BCOLORS.OKGREEN}App Inspect Passed!")
                     if "warning" in result["summary"] and result["summary"]["warning"]:
-                        print("Warning List:")
+                        print(f"{BCOLORS.OKBLUE}Warning List:")
                         for group in result["reports"][0]["groups"]:
                             for check in group["checks"]:
                                 if check["result"] == "warning":
+                                    print(f'{BCOLORS.WARNING} {check["name"]}')
                                     for msg in check["messages"]:
                                         print(msg["message"])
-                    pprint(result["summary"])
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    format_result(result["summary"])
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=pass", file=fh)
                 else:
-                    print(f"App Inspect returned {failures} failures.")
+                    print(f"{BCOLORS.BOLD}{BCOLORS.FAIL}App Inspect returned {failures} failures.")
                     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                         print("status=fail", file=fh)
-                    pprint(result["summary"])
-                    print("Failure List:")
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} SUMMARY')
+                    format_result(result["summary"])
+                    print(f'{BCOLORS.OKBLUE}{BCOLORS.BOLD} Failure List:')
                     for group in result["reports"][0]["groups"]:
                         for check in group["checks"]:
                             if check["result"] == "failure":
+                                print(f'{BCOLORS.FAIL} {check["name"]}')
                                 for msg in check["messages"]:
                                     print(msg["message"])
                     sys.exit(1)

--- a/reporter.py
+++ b/reporter.py
@@ -1,7 +1,9 @@
 import json
 import os
 import sys
+
 import tabulate
+
 
 class BCOLORS:
     HEADER = "\033[95m"
@@ -12,6 +14,7 @@ class BCOLORS:
     FAIL = "\033[91m"
     BOLD = "\033[1m"
 
+
 def format_result(result):
     restructured_result = [
         "success",
@@ -20,10 +23,11 @@ def format_result(result):
         "skipped",
         "warning",
         "error",
-        "failure"
+        "failure",
     ]
     row = [[result[x] for x in restructured_result]]
     print(tabulate.tabulate(row, restructured_result))
+
 
 def main(args):
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml==5.4.1
-splunk-appinspect==2.14.1
+splunk-appinspect==2.30.0
+tabulate==0.9.0


### PR DESCRIPTION
Following changes have been done as part of this PR

- Instead of maintaining a single file for manual checks and exception, now action will use two individual files, .appinspect.manual.check and .appinspect.expect
- Added a validation to check all the expected checks which are mentioned in .appinspect.expect must contain a ticket id starting with ADDON/APPCERT
- Removed condition for checking manual_check is vetted only when included tag is manual, action will check if manual_check is vetted or not for all the tags
- Upgraded Appinspect version to the latest available 2.30.0
- Made enhancements to better represent test report in CI stage for easy understanding