### PR TITLE
chore: upgrade python3.9 for running appinspect cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.7.10
+FROM python:3.9.18
 
 COPY requirements.txt /
 RUN pip install --no-cache-dir --prefer-binary -r /requirements.txt


### PR DESCRIPTION
AppInspect v3.0.0 shows the following change:

> Mainly, this means changing os.path.join() to any of its object-oriented alternative, e.g. pathlib.Path(). Refer to the [official pathlib migration guide](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module).

Now, the error I'm seeing is
```
      Check that all XML files are well-formed. 
          ERROR: 'PosixPath' object has no attribute 
              'getCharacterStream' 
```

Which leads me to believe that we're encountering [this issue](https://github.com/python/cpython/issues/75839) because the action runs the command with Python 3.7 and the fix for this issue only landed in 3.8.
Could it be that this makes appinspect-cli==3.0.0 partially incompatible with 3.7?

From what I've been seeing, the `appinspect-cli` command is independent of any Python version that Splunk uses, so we can upgrade the runtime to Python 3.9. 

@artemrys I'm not sure how to upgrade the image path in lockstep with the release so marking this as a draft for now.
Also, I have not tested this change yet.

https://github.com/splunk/appinspect-cli-action/blob/bf9e3bc36cf840f5a01f4b63fb157c027073698a/action.yml#L38