### PR TITLE
ci: use latest python for pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,12 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1
 
   build_action:


### PR DESCRIPTION
This PR sets python version to 3.12 for per-commit
Reference: [ADDON-75861](https://splunk.atlassian.net/browse/ADDON-75861)